### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/jettify/uf-sbus/compare/v0.1.0...v0.1.1) - 2025-09-02
+
+### Other
+
+- Update README and update dependencies for example.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "uf-sbus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "defmt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uf-sbus"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nickolai Novik <nickolainovik@gmail.com>"]
 repository = "https://github.com/jettify/uf-sbus"
 description = "A `no_std` Rust library for parsing the SBUS protocol, designed for embedded environments"


### PR DESCRIPTION



## 🤖 New release

* `uf-sbus`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/jettify/uf-sbus/compare/v0.1.0...v0.1.1) - 2025-09-02

### Other

- Update README and update dependencies for example.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).